### PR TITLE
Update to_s to insert an additional new line for no text

### DIFF
--- a/lib/srt/line.rb
+++ b/lib/srt/line.rb
@@ -42,7 +42,7 @@ module SRT
 
     def to_s(time_str_function=:time_str)
       # ensure a new line is added for an empty text block
-      txt = if text.empty? then [""] else text end
+      txt = text.empty? ? [""] : text
       [sequence, (display_coordinates ? send(time_str_function) + display_coordinates : send(time_str_function)), txt , ''].flatten.join("\n")
     end
   end

--- a/lib/srt/line.rb
+++ b/lib/srt/line.rb
@@ -41,7 +41,9 @@ module SRT
     end
 
     def to_s(time_str_function=:time_str)
-      [sequence, (display_coordinates ? send(time_str_function) + display_coordinates : send(time_str_function)), text, ''].flatten.join("\n")
+      # ensure a new line is added for an empty text block
+      txt = if text.empty? then [""] else text end
+      [sequence, (display_coordinates ? send(time_str_function) + display_coordinates : send(time_str_function)), txt , ''].flatten.join("\n")
     end
   end
 end

--- a/lib/srt/line.rb
+++ b/lib/srt/line.rb
@@ -41,9 +41,9 @@ module SRT
     end
 
     def to_s(time_str_function=:time_str)
-      # ensure a new line is added for an empty text block
-      txt = text.empty? ? [""] : text
-      [sequence, (display_coordinates ? send(time_str_function) + display_coordinates : send(time_str_function)), txt , ''].flatten.join("\n")
+      content = text.empty? ? [''] : text
+      coordinates = display_coordinates ? display_coordinates : ""
+      [sequence, send(time_str_function) + coordinates, content, ""].flatten.join("\n")
     end
   end
 end

--- a/spec/line_spec.rb
+++ b/spec/line_spec.rb
@@ -22,4 +22,17 @@ describe SRT::Line do
       expect(line.time_str).to eq("00:03:44,200 --> 00:04:04,578")
     end
   end
+
+  describe "#to_s" do
+    let(:line) { SRT::Line.new }
+
+    before do
+      line.sequence = "1"
+      line.start_time = 224.2
+      line.end_time = 244.578
+    end
+    it "should produce timecodes that match the internal float values" do
+      expect(line.to_s).to eq("1\n00:03:44,200 --> 00:04:04,578\n\n")
+    end
+  end
 end

--- a/spec/line_spec.rb
+++ b/spec/line_spec.rb
@@ -31,8 +31,11 @@ describe SRT::Line do
       line.start_time = 224.2
       line.end_time = 244.578
     end
-    it "should produce timecodes that match the internal float values" do
-      expect(line.to_s).to eq("1\n00:03:44,200 --> 00:04:04,578\n\n")
+    
+    context "with empty content" do
+      it "creates a valid empty node" do
+        expect(line.to_s).to eq("1\n00:03:44,200 --> 00:04:04,578\n\n")
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, when there's a line with no text, `to_s` produces no additional newlines for the srt file. This causes issues for web players to not parse the SRT file correctly. The update to `to_s` will ensure that a line with empty text produces two new lines instead of just one.